### PR TITLE
Add unit tests for UData class functionality

### DIFF
--- a/test/udata_test.py
+++ b/test/udata_test.py
@@ -1,0 +1,85 @@
+import unittest
+import io
+from unittest.mock import MagicMock
+from your_module.udata import UData
+from accumulator import BatchProof, LeafData
+
+class TestUData(unittest.TestCase):
+    def setUp(self):
+        self.mock_batch_proof = MagicMock(spec=BatchProof)
+        self.mock_batch_proof.targets = [0, 1]
+        self.mock_batch_proof.serialize = MagicMock()
+        self.mock_batch_proof.deserialize = MagicMock()
+        self.mock_batch_proof.serialize_size = MagicMock(return_value=10)
+
+        self.mock_leaf_data = MagicMock(spec=LeafData)
+        self.mock_leaf_data.serialize = MagicMock()
+        self.mock_leaf_data.deserialize = MagicMock()
+        self.mock_leaf_data.serialize_size = MagicMock(return_value=20)
+        self.mock_leaf_data.leaf_hash = MagicMock(return_value=b"hash")
+
+        self.udata = UData(
+            height=42,
+            acc_proof=self.mock_batch_proof,
+            stxos=[self.mock_leaf_data, self.mock_leaf_data],
+            txo_ttls=[100, 200]
+        )
+
+    def test_proof_sanity(self):
+        self.assertTrue(self.udata.proof_sanity(0, 0))
+
+    def test_serialize_and_deserialize(self):
+        buf = io.BytesIO()
+
+        self.udata.serialize(buf)
+        serialized_data = buf.getvalue()
+
+        self.mock_batch_proof.serialize.assert_called_once()
+        self.assertEqual(self.mock_leaf_data.serialize.call_count, 2)
+
+        buf.seek(0)
+        new_udata = UData()
+        new_udata.deserialize(buf)
+
+        self.assertEqual(new_udata.height, self.udata.height)
+        self.assertEqual(new_udata.txo_ttls, self.udata.txo_ttls)
+
+        self.mock_batch_proof.deserialize.assert_called_once()
+        self.assertEqual(len(new_udata.stxos), 2)
+        self.assertEqual(self.mock_leaf_data.deserialize.call_count, 2)
+
+    def test_serialize_size(self):
+        size = self.udata.serialize_size()
+        expected_size = 8 + (4 * len(self.udata.txo_ttls)) + 10 + (2 * 20)
+        self.assertEqual(size, expected_size)
+
+    def test_deserialize_invalid_data(self):
+        buf = io.BytesIO(b"\x00\x00\x00\x2A\x00\x00\x00\x02\x00\x00")
+        with self.assertRaises(ValueError):
+            self.udata.deserialize(buf)
+
+    def test_gen_udata(self):
+        mock_forest = MagicMock()
+        mock_forest.prove_batch = MagicMock(return_value=self.mock_batch_proof)
+        mock_forest.stats = MagicMock(return_value="mock stats")
+
+        del_leaves = [self.mock_leaf_data, self.mock_leaf_data]
+        height = 100
+
+        result = UData.gen_udata(del_leaves, mock_forest, height)
+
+        self.assertEqual(result.height, height)
+        self.assertEqual(result.stxos, del_leaves)
+        self.assertEqual(result.acc_proof, self.mock_batch_proof)
+        mock_forest.prove_batch.assert_called_once_with([b"hash", b"hash"])
+
+    def test_gen_udata_proof_mismatch(self):
+        mock_forest = MagicMock()
+        mock_forest.prove_batch = MagicMock(return_value=self.mock_batch_proof)
+
+        del_leaves = [self.mock_leaf_data]
+        with self.assertRaises(ValueError):
+            UData.gen_udata(del_leaves, mock_forest, 100)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
- Implement tests for `proof_sanity` to verify proof consistency.
- Add serialization and deserialization tests to ensure correct binary stream handling.
- Validate `serialize_size` to calculate expected serialized size accurately.
- Test error handling for invalid or incomplete deserialization data.
- Add tests for `gen_udata` to verify proper generation of UData with proofs.
- Ensure `gen_udata` raises errors for mismatched proof targets and leaves.
- Use mocks for BatchProof, LeafData, and Forest to isolate dependencies.